### PR TITLE
Fixes for new txzmq version

### DIFF
--- a/houseagent/core/coordinator.py
+++ b/houseagent/core/coordinator.py
@@ -1,6 +1,6 @@
 import json
 import time
-from txZMQ import ZmqFactory, ZmqEndpoint, ZmqEndpointType, ZmqConnection
+from txzmq import ZmqFactory, ZmqEndpoint, ZmqEndpointType, ZmqConnection
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import deferLater
 from twisted.internet import reactor, defer
@@ -125,7 +125,7 @@ class Coordinator(object):
         
         @return: nothing
         '''
-        self.broker = Broker(self.factory, self, ZmqEndpoint(ZmqEndpointType.Bind, 'tcp://%s:%s' % (host, port)))
+        self.broker = Broker(self.factory, self, ZmqEndpoint(ZmqEndpointType.bind, 'tcp://%s:%s' % (host, port)))
 
     def handle_plugin_ready(self, routing_info, payload):
         '''

--- a/houseagent/plugins/pluginapi.py
+++ b/houseagent/plugins/pluginapi.py
@@ -17,7 +17,7 @@ if os.name == "nt":
         pass        
 #from twisted.python import log as twisted_log
 from twisted.internet import reactor, task, defer
-from txZMQ import ZmqFactory, ZmqEndpoint, ZmqConnection, ZmqEndpointType
+from txzmq import ZmqFactory, ZmqEndpoint, ZmqConnection, ZmqEndpointType
 from zmq.core import constants
 from houseagent import config_file
 


### PR DESCRIPTION
Running house agent against easy_installed txzmq 0.5 on linux failed.
Few minor fixes to be compatible with new version of txzmq. Runs fine on ubuntu now with instructions provided in this thread http://www.houseagent.nl/forum/viewtopic.php?f=6&t=56

The problems in the last post in the thread should be solved by this.
